### PR TITLE
Update to 5.8.0

### DIFF
--- a/ads/build.gradle
+++ b/ads/build.gradle
@@ -24,7 +24,7 @@ repositories {
     jcenter()
 
     // region FluctSDK
-    maven { url 'https://raw.github.com/voyagegroup/FluctSDK-Android/master/m2/repository/' }
+    maven { url 'https://voyagegroup.github.com/FluctSDK-Android/m2/repository/' }
     // endregion
 
     // region FluctSDK Mediation

--- a/ads/build.gradle
+++ b/ads/build.gradle
@@ -41,21 +41,21 @@ dependencies {
     // endregion
 
     // region FluctSDK
-    implementation 'jp.fluct:FluctSDK:5.7.0'
+    implementation 'jp.fluct:FluctSDK:5.8.0'
     implementation 'com.google.android.gms:play-services-base:16.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:16.0.0'
     // endregion
 
     // region FluctSDK GMA Mediation
-    implementation 'jp.fluct.mediation.gma:gma-mediation:1.3.0'
+    implementation 'jp.fluct.mediation.gma:gma-mediation:1.4.0'
     // endregion
 
     // region FluctSDK Mediations
     implementation 'com.maio:android-sdk:1.1.8'
     implementation 'com.unity3d.ads:unity-ads:3.1.0'
     implementation 'com.adcolony:sdk:3.3.7'
-    implementation 'jp.fluct.mediation:rewardedvideo-mediation-maio:2.7.0'
-    implementation 'jp.fluct.mediation:rewardedvideo-mediation-unityads:2.7.0'
-    implementation 'jp.fluct.mediation:rewardedvideo-mediation-adcolony:2.7.0'
+    implementation 'jp.fluct.mediation:rewardedvideo-mediation-maio:2.8.0'
+    implementation 'jp.fluct.mediation:rewardedvideo-mediation-unityads:2.8.0'
+    implementation 'jp.fluct.mediation:rewardedvideo-mediation-adcolony:2.8.0'
     // endregion
 }

--- a/ads/build.gradle
+++ b/ads/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
     }
 
     buildTypes {


### PR DESCRIPTION
I just updated to the latest release of FluctSDK like [Standard example](https://github.com/voyagegroup/GMA-Mediation-FluctSDK-Android/pull/5). This release is contained the maven-url changes.